### PR TITLE
Fixed bug where user can draw on top of toolbar

### DIFF
--- a/flutter-app/flutter_drawing_app/starter/lib/drawing_page.dart
+++ b/flutter-app/flutter_drawing_app/starter/lib/drawing_page.dart
@@ -387,9 +387,17 @@ Widget buildUploadButton() {
       backgroundColor: Colors.white10,
       body: Stack(
         children: <Widget>[
-          determineDisplayContent(_width, _height)
-          ,
+          determineDisplayContent(_width, _height),
           buildCurrentPath(context),
+          Positioned(child: Container(
+            color: Colors.white,
+            alignment: Alignment.centerRight,
+          ),
+            right: 0,
+            top: 0,
+            width: 0.05 * _width,
+            height: _height,
+          ),
           buildColorToolbar(),
           buildStrokeToolbar(),
         ],


### PR DESCRIPTION
Short term solution to the toolbar drawing fix. We should probably aim to create a single method containing our toolbar rather than splitting it up to solve this problem. This works for now though.